### PR TITLE
Add instrumented tests to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,8 +56,11 @@ jobs:
 
   build:
     needs: [ lint ]
-    name: "Build and run tests"
-    runs-on: macos-latest
+    name: "Build and test app"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        api-level: [ 21, 35 ]
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v4.2.2
@@ -69,3 +72,13 @@ jobs:
       - name: "Build with Gradle"
         run: |
           ./gradlew assemble --stacktrace
+      - name: "Enable KVM"
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: "Run tests"
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          script: ./gradlew connectedCheck

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,12 @@ jobs:
     name: "Build and test app"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         api-level: [ 21, 35 ]
+        arch: [ x86_64 ]
+        target: [ google_apis ]
+        channel: [ stable ]
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v4.2.2
@@ -81,4 +85,6 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: ${{ matrix.arch }}
           script: ./gradlew connectedCheck


### PR DESCRIPTION
## Summary

Add the running of instrumented tests to generic checks CI workflow

## Changes

* Calls `reactivecircus/android-emulator-runner@v2` with Android EMUs running API levels 21 and 35

## Checklist

<!--
    Please ensure these key steps are followed before marking a pull request for review
-->

- [x] I have performed a self-review of my own code
- [x] I have added necessary tests (including edge cases) for the changes introduced (if applicable)
- [x] I have updated the documentation to reflect my changes (if applicable)

## Testing Notes

N/A