### PR TITLE
Bump minSdk from 21 to 23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 21, 35 ]
+        api-level: [ 23, 35 ]
         arch: [ x86_64 ]
         target: [ google_apis ]
         channel: [ stable ]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <a href="https://github.com/ed-george/encrypted-shared-preferences/releases"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/ed-george/encrypted-shared-preferences"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img alt="License" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"/></a>
-  <a href="https://android-arsenal.com/api?level=21"><img alt="API" src="https://img.shields.io/badge/API-21%2B-brightgreen.svg?style=flat"/></a>
+  <a href="https://developer.android.com/about/versions/marshmallow"><img alt="API" src="https://img.shields.io/badge/API-23%2B-brightgreen.svg?style=flat"/></a>
   <a href="https://github.com/ed-george/encrypted-shared-preferences/actions/workflows/build.yml?query=branch%3Amain"><img alt="Main branch status" src="https://img.shields.io/github/checks-status/ed-george/encrypted-shared-preferences/main">
 </a>
 </p>
@@ -99,6 +99,15 @@ Within your code, replace any existing instances (e.g. imports) of `androidx.sec
 ### Known Issues
 
 * Any encrypted shared preference file(s) or encrypted file(s) should _not_ be backed up with Auto Backup as, when restoring, it is likely the key used to encrypt it will no longer be present and will cause runtime crashes. You should therefore exclude all `EncryptedSharedPreference` or `EncryptedFile` from a backup using [backup rules](https://developer.android.com/guide/topics/data/autobackup#IncludingFiles).
+
+#### Min SDK 21 Support
+As of Tink Android version 1.18.0, support for Android SDK version 21 (Android 5.0 Lollipop) was removed and replaced with a min SDK version of 23 (Android 6.0 Marshmallow).
+
+This change is present in this library's 1.1.x (and above) releases and therefore removes ongoing support for SDK 21 in favour of keeping dependencies up to date.
+
+However, to gauge the impact on users of this library, if this change is problematic for your application please do [raise an issue](https://github.com/ed-george/encrypted-shared-preferences/issues/new) to highlight this.
+
+For more information see https://github.com/ed-george/encrypted-shared-preferences/pull/24
 
 ## License
 ```xml

--- a/buildSrc/src/main/kotlin/dev/spght/encryptedprefs/Configuration.kt
+++ b/buildSrc/src/main/kotlin/dev/spght/encryptedprefs/Configuration.kt
@@ -3,7 +3,7 @@ package dev.spght.encryptedprefs
 object Configuration {
     const val compileSdk = 35
     const val targetSdk = 35
-    const val minSdk = 21
+    const val minSdk = 23
 
     const val majorVersion = 1
     const val minorVersion = 1

--- a/sharedprefs-core/src/androidTest/java/dev/spght/encryptedprefs/EncryptedFileTest.java
+++ b/sharedprefs-core/src/androidTest/java/dev/spght/encryptedprefs/EncryptedFileTest.java
@@ -39,7 +39,6 @@ import java.io.OutputStream;
 import java.security.KeyStore;
 import java.util.ArrayList;
 import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -416,11 +415,6 @@ public class EncryptedFileTest {
             File file = new File(directory + "/multiThreadFileCreate-file-" + i);
             file.delete(); // Clear out file from previous run if it exists
             files.add(file);
-        }
-        // Inlining what should just be Assume.assumeTrue(SDK_INT >= M) because AndroidStudio's
-        // static analysis can't understand that.
-        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.M) {
-            throw new AssumptionViolatedException("API v23 or higher is required to run this test");
         }
 
         final String masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC);

--- a/sharedprefs-core/src/androidTest/java/dev/spght/encryptedprefs/MasterKeySecureTest.java
+++ b/sharedprefs-core/src/androidTest/java/dev/spght/encryptedprefs/MasterKeySecureTest.java
@@ -20,11 +20,9 @@ import static android.content.Context.MODE_PRIVATE;
 import android.app.KeyguardManager;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.MediumTest;
-import androidx.test.filters.SdkSuppress;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -44,7 +42,6 @@ import org.junit.runner.RunWith;
  */
 @MediumTest
 @RunWith(AndroidJUnit4.class)
-@SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
 public class MasterKeySecureTest {
     private static final String PREFS_FILE = "test_shared_prefs";
 
@@ -88,9 +85,8 @@ public class MasterKeySecureTest {
         keyStore.deleteEntry("_androidx_security_master_key_");
     }
 
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
     @Test
-    public void testCreateKeyWithAuthenicationRequired()
+    public void testCreateKeyWithAuthenticationRequired()
             throws GeneralSecurityException, IOException {
         MasterKey masterKey =
                 new MasterKey.Builder(ApplicationProvider.getApplicationContext())

--- a/sharedprefs-core/src/androidTest/java/dev/spght/encryptedprefs/MasterKeyTest.java
+++ b/sharedprefs-core/src/androidTest/java/dev/spght/encryptedprefs/MasterKeyTest.java
@@ -19,13 +19,11 @@ import static android.content.Context.MODE_PRIVATE;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.MediumTest;
-import androidx.test.filters.SdkSuppress;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -42,7 +40,6 @@ import org.junit.runner.RunWith;
  * href="https://android.googlesource.com/platform/frameworks/support/+/e50caacef9794c6c1d05ed647347a01b06b96930/security/security-crypto/src/androidTest/java/androidx/security/crypto/MasterKeyTest.java">e50caac</a>
  */
 @MediumTest
-@SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
 @RunWith(AndroidJUnit4.class)
 public class MasterKeyTest {
     private static final String PREFS_FILE = "test_shared_prefs";

--- a/sharedprefs-core/src/androidTest/java/dev/spght/encryptedprefs/MasterKeysTest.java
+++ b/sharedprefs-core/src/androidTest/java/dev/spght/encryptedprefs/MasterKeysTest.java
@@ -19,13 +19,11 @@ import static android.content.Context.MODE_PRIVATE;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.MediumTest;
-import androidx.test.filters.SdkSuppress;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -42,7 +40,6 @@ import org.junit.runner.RunWith;
  * href="https://android.googlesource.com/platform/frameworks/support/+/e50caacef9794c6c1d05ed647347a01b06b96930/security/security-crypto/src/androidTest/java/androidx/security/crypto/MasterKeysTest.java">e50caac</a>
  */
 @MediumTest
-@SdkSuppress(minSdkVersion = Build.VERSION_CODES.M)
 @RunWith(AndroidJUnit4.class)
 public class MasterKeysTest {
     private static final String PREFS_FILE = "test_shared_prefs";

--- a/sharedprefs-core/src/main/java/dev/spght/encryptedprefs/MasterKey.java
+++ b/sharedprefs-core/src/main/java/dev/spght/encryptedprefs/MasterKey.java
@@ -38,9 +38,8 @@ import java.security.cert.CertificateException;
 /**
  * Wrapper for a master key used in the library.
  *
- * <p>On Android M (API 23) and above, this is class references a key that's stored in the Android
- * Keystore. On Android L (API 21, 22), there isn't a master key. <hr> Based on MasterKey.java from
- * AndroidX Crypto - v1.1.0-alpha07
+ * <p>This class references a key that's stored in the Android Keystore. <hr> Based on
+ * MasterKey.java from AndroidX Crypto - v1.1.0-alpha07
  *
  * <p>Permalink: <a
  * href="https://android.googlesource.com/platform/frameworks/support/+/e50caacef9794c6c1d05ed647347a01b06b96930/security/security-crypto/src/main/java/androidx/security/crypto/MasterKey.java">e50caac</a>
@@ -72,25 +71,15 @@ public final class MasterKey {
 
     /* package */ MasterKey(@NonNull String keyAlias, @Nullable Object keyGenParameterSpec) {
         mKeyAlias = keyAlias;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            mKeyGenParameterSpec = (KeyGenParameterSpec) keyGenParameterSpec;
-        } else {
-            mKeyGenParameterSpec = null;
-        }
+        mKeyGenParameterSpec = (KeyGenParameterSpec) keyGenParameterSpec;
     }
 
     /**
      * Checks if this key is backed by the Android Keystore.
      *
-     * @return {@code true} if the key is in Android Keystore, {@code false} otherwise. This method
-     *     always returns false when called on Android Lollipop (API 21 and 22).
+     * @return {@code true} if the key is in Android Keystore, {@code false} otherwise.
      */
     public boolean isKeyStoreBacked() {
-        // Keystore is not used prior to Android M (API 23)
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return false;
-        }
-
         try {
             KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
             keyStore.load(null);
@@ -103,15 +92,8 @@ public final class MasterKey {
         }
     }
 
-    /**
-     * Gets whether user authentication is required to use this key.
-     *
-     * <p>This method always returns {@code false} on Android L (API 21 + 22).
-     */
+    /** Gets whether user authentication is required to use this key. */
     public boolean isUserAuthenticationRequired() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return false;
-        }
         return mKeyGenParameterSpec != null
                 && Api23Impl.isUserAuthenticationRequired(mKeyGenParameterSpec);
     }
@@ -119,16 +101,10 @@ public final class MasterKey {
     /**
      * Gets the duration in seconds that the key is unlocked for following user authentication.
      *
-     * <p>The value returned for this method is only meaningful on Android M+ (API 23) when {@link
-     * #isUserAuthenticationRequired()} returns {@code true}.
-     *
      * @return The duration the key is unlocked for in seconds.
      */
     @SuppressLint("MethodNameUnits")
     public int getUserAuthenticationValidityDurationSeconds() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return 0;
-        }
         return mKeyGenParameterSpec == null
                 ? 0
                 : Api23Impl.getUserAuthenticationValidityDurationSeconds(mKeyGenParameterSpec);
@@ -201,11 +177,9 @@ public final class MasterKey {
         public @NonNull Builder setKeyScheme(@NonNull KeyScheme keyScheme) {
             switch (keyScheme) {
                 case AES256_GCM:
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                        if (mKeyGenParameterSpec != null) {
-                            throw new IllegalArgumentException(
-                                    "KeyScheme set after setting a " + "KeyGenParamSpec");
-                        }
+                    if (mKeyGenParameterSpec != null) {
+                        throw new IllegalArgumentException(
+                                "KeyScheme set after setting a " + "KeyGenParamSpec");
                     }
                     break;
                 default:
@@ -274,7 +248,6 @@ public final class MasterKey {
          * @param keyGenParameterSpec The key spec to use.
          * @return This builder.
          */
-        @RequiresApi(Build.VERSION_CODES.M)
         public @NonNull Builder setKeyGenParameterSpec(
                 @NonNull KeyGenParameterSpec keyGenParameterSpec) {
             if (mKeyScheme != null) {
@@ -299,14 +272,9 @@ public final class MasterKey {
          * @return The master key.
          */
         public @NonNull MasterKey build() throws GeneralSecurityException, IOException {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                return Api23Impl.build(this);
-            } else {
-                return new MasterKey(mKeyAlias, null);
-            }
+            return Api23Impl.build(this);
         }
 
-        @RequiresApi(23)
         static class Api23Impl {
             private Api23Impl() {
                 // This class is not instantiable.
@@ -390,7 +358,6 @@ public final class MasterKey {
         }
     }
 
-    @RequiresApi(23)
     static class Api23Impl {
         private Api23Impl() {
             // This class is not instantiable.

--- a/sharedprefs-core/src/main/java/dev/spght/encryptedprefs/MasterKeys.java
+++ b/sharedprefs-core/src/main/java/dev/spght/encryptedprefs/MasterKeys.java
@@ -15,11 +15,9 @@
  */
 package dev.spght.encryptedprefs;
 
-import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -37,7 +35,6 @@ import javax.crypto.KeyGenerator;
  * <p>Permalink: <a
  * href="https://android.googlesource.com/platform/frameworks/support/+/e50caacef9794c6c1d05ed647347a01b06b96930/security/security-crypto/src/main/java/androidx/security/crypto/MasterKeys.java">e50caac</a>
  */
-@RequiresApi(Build.VERSION_CODES.M)
 public final class MasterKeys {
     private MasterKeys() {}
 


### PR DESCRIPTION
## Summary

> [!WARNING]
> This PR raises the `minSdk` for the library from API 21 (Android 5.0 - Lollipop) to API 23 (Android 6 - Marshmallow)
>
> For apps on API 21 and 22, this is a **breaking** change
>
> If this change is problematic for your application, please do [raise an issue](https://github.com/ed-george/encrypted-shared-preferences/issues/new) to highlight this. 

## Changes

In preparation for Tink version 1.18.0, the `minSdk` API version must be raised from 21 to 23.

- Bump `minSdk` version
- Update documentation
- Update CI pipeline(s)
- Remove dead code / comments

## Checklist

<!--
    Please ensure these key steps are followed before marking a pull request for review
-->

- [x] I have performed a self-review of my own code
- [x] I have added necessary tests (including edge cases) for the changes introduced (if applicable)
- [x] I have updated the documentation to reflect my changes (if applicable)

## Testing Notes

Pray for green builds! 🙏💚

<!--
    Add any additional comments, instructions, or insights about how to test this pull request
-->